### PR TITLE
Update pro guard rules to exclude SdlRemoteDisplay

### DIFF
--- a/docs/Proguard Guidelines/index.md
+++ b/docs/Proguard Guidelines/index.md
@@ -23,6 +23,7 @@ Developers using Proguard in this manner should be sure to include the following
 ```java
 -keep class com.smartdevicelink.** { *; }
 -keep class com.livio.** { *; }
+# Video streaming apps must add the following line
 -keep class ** extends com.smartdevicelink.streaming.video.SdlRemoteDisplay { *; }
 ```
 

--- a/docs/Proguard Guidelines/index.md
+++ b/docs/Proguard Guidelines/index.md
@@ -23,6 +23,7 @@ Developers using Proguard in this manner should be sure to include the following
 ```java
 -keep class com.smartdevicelink.** { *; }
 -keep class com.livio.** { *; }
+-keep class ** extends com.smartdevicelink.streaming.video.SdlRemoteDisplay { *; }
 ```
 
 !!! note


### PR DESCRIPTION
ProgGuard rules updated to exclude SdlRemoteDisplay class from being obfuscated 